### PR TITLE
Add class names, follow SUITcss naming conventions

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -8,9 +8,9 @@ class App extends React.Component {
     return (
       <div className="demo">
         <Ecology
-          overview={require('!!raw!./ecology.md')}
-          source={require('json!./sample.json')}
-          scope={{React, SampleClass: require('./sample')}}/>
+          overview={require("!!raw!./ecology.md")}
+          source={require("json!./sample.json")}
+          scope={{React, SampleClass: require("./sample")}}/>
       </div>
     );
   }

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -10,7 +10,7 @@ class App extends React.Component {
         <Ecology
           overview={require("!!raw!./ecology.md")}
           source={require("json!./sample.json")}
-          scope={{React, SampleClass: require("./sample")}}/>
+          scope={{React, ReactDOM, SampleClass: require("./sample")}}/>
       </div>
     );
   }

--- a/demo/ecology.md
+++ b/demo/ecology.md
@@ -10,7 +10,7 @@ var App = React.createClass({
     }
 })
 
-React.render(<App/>, mountNode);
+ReactDOM.render(<App/>, mountNode);
 ```
 
 ## Look At Me

--- a/demo/ecology.md
+++ b/demo/ecology.md
@@ -6,7 +6,7 @@ var App = React.createClass({
   render() {
       return (
       <SampleClass/>
-      )
+      );
     }
 })
 

--- a/demo/sample.jsx
+++ b/demo/sample.jsx
@@ -38,7 +38,7 @@ SampleClass.propTypes = {
 SampleClass.defaultProps = {
   count: 1,
   name: "test",
-  indexes: [1,2,3],
+  indexes: [1, 2, 3],
   optionalUnion: 5
 };
 

--- a/demo/sample.jsx
+++ b/demo/sample.jsx
@@ -24,7 +24,7 @@ SampleClass.propTypes = {
   /**
    * Indexes test
    */
-  indexes: React.PropTypes.arrayOf(React.PropTypes.instanceOf(Test)),
+  indexes: React.PropTypes.arrayOf(React.PropTypes.number),
   /**
    * Union test
    */

--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -6,24 +6,24 @@ const makeArray = (obj) =>
 
 const renderType = ({name, value}) => {
   switch (name) {
-    case "union": {
-      return value.map((val) => val.name).join(', ');
-    }
-    case "enum": {
-      return value.map((val) => val.value).join(', ');
-    }
-    case "instanceOf": {
-      return value
-    }
-    case "arrayOf": {
-      return `Array<${renderType(value)}>`;
-    }
-    case "shape": {
-      return `{${Object.keys(value).map((val) => val + ': ' + renderType(value[val])).join(', ')}}`;
-    }
-    default: {
-      return name;
-    }
+  case "union": {
+    return value.map((val) => val.name).join(', ');
+  }
+  case "enum": {
+    return value.map((val) => val.value).join(', ');
+  }
+  case "instanceOf": {
+    return value;
+  }
+  case "arrayOf": {
+    return `Array<${renderType(value)}>`;
+  }
+  case "shape": {
+    return `{${Object.keys(value).map((val) => val + ': ' + renderType(value[val])).join(', ')}}`;
+  }
+  default: {
+    return name;
+  }
   }
 };
 
@@ -53,17 +53,19 @@ export default class API extends React.Component {
                   {prop.required && <span className="Prop-required">required</span>}
                 </td>
                 <td>
-                  {'description' in prop ?
+                  {"description" in prop ?
                   <span className="Prop-description">
                     {prop.description.split("@examples")[0]}
                   </span> : null}
-                  {'description' in prop && prop.description.indexOf("@examples") !== -1 ?
+                  {"description" in prop && prop.description.indexOf("@examples") !== -1 ?
                     <span className="Prop-examples">
                       <span className="Prop-examples-title">Examples: </span>
-                      <span className="Prop-examples-value">{prop.description.split("@examples")[1]}</span>
-                    </span>  :
+                      <span className="Prop-examples-value">
+                        {prop.description.split("@examples")[1]}
+                      </span>
+                    </span> :
                     null}
-                  {'defaultValue' in prop ?
+                  {"defaultValue" in prop ?
                     <span className="Prop-default">
                       <span className="Prop-default-title">Default Value: </span>
                       <span className="Prop-default-value">{prop.defaultValue.value}</span>
@@ -71,10 +73,14 @@ export default class API extends React.Component {
                     null}
                 </td>
               </tr>
-            )
+            );
           })}
         </tbody>
       </table>
     );
   }
 }
+
+API.propTypes = {
+  source: React.PropTypes.object
+};

--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -32,7 +32,7 @@ export default class API extends React.Component {
     const docObj = this.props.source;
     const propMap = makeArray(docObj.props);
     return (
-      <table>
+      <table className="Props">
         <thead>
           <tr>
             <th>Props</th>
@@ -42,31 +42,31 @@ export default class API extends React.Component {
         <tbody>
           {propMap.map((prop, index) => {
             return (
-              <tr key={index}>
+              <tr key={index} className="Prop">
                 <td>
-                  <span className="prop__name">
+                  <span className="Prop-name">
                     {prop.name}
                   </span>
-                  <span className="prop__type">
+                  <span className="Prop-type">
                     {renderType({...prop.type})}
                   </span>
-                  {prop.required && <span className="prop__required">required</span>}
+                  {prop.required && <span className="Prop-required">required</span>}
                 </td>
                 <td>
                   {'description' in prop ?
-                  <span className="prop__description">
+                  <span className="Prop-description">
                     {prop.description.split("@examples")[0]}
                   </span> : null}
                   {'description' in prop && prop.description.indexOf("@examples") !== -1 ?
-                    <span className="prop__examples">
-                      <span className="prop__examples-title">Examples: </span>
-                      <span className="prop__examples-value">{prop.description.split("@examples")[1]}</span>
+                    <span className="Prop-examples">
+                      <span className="Prop-examples-title">Examples: </span>
+                      <span className="Prop-examples-value">{prop.description.split("@examples")[1]}</span>
                     </span>  :
                     null}
                   {'defaultValue' in prop ?
-                    <span className="prop__default">
-                      <span className="prop__default-title">Default Value: </span>
-                      <span className="prop__default-value">{prop.defaultValue.value}</span>
+                    <span className="Prop-default">
+                      <span className="Prop-default-title">Default Value: </span>
+                      <span className="Prop-default-value">{prop.defaultValue.value}</span>
                     </span> :
                     null}
                 </td>

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -10,7 +10,7 @@ export default class Ecology extends React.Component {
           <Overview markdown={this.props.overview} scope={this.props.scope}/>
         </div>
         <div className="Documentation">
-          <API source={this.props.source}/>
+          <API source={this.props.source} playgroundtheme={this.props.playgroundtheme}/>
         </div>
       </div>
     );
@@ -19,6 +19,7 @@ export default class Ecology extends React.Component {
 
 Ecology.propTypes = {
   overview: React.PropTypes.string,
+  playgroundtheme: React.PropTypes.string,
   source: React.PropTypes.object,
   scope: React.PropTypes.object
 };

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -1,14 +1,17 @@
 import React from "react";
 import API from "./api";
-import Playground from "component-playground";
 import Overview from "./overview";
 
 export default class Ecology extends React.Component {
   render() {
     return (
       <div className="Ecology">
-        <div className="Overview"><Overview markdown={this.props.overview} scope={this.props.scope}/></div>
-        <div className="Documentation"><API source={this.props.source}/></div>
+        <div className="Overview">
+          <Overview markdown={this.props.overview} scope={this.props.scope}/>
+        </div>
+        <div className="Documentation">
+          <API source={this.props.source}/>
+        </div>
       </div>
     );
   }
@@ -18,4 +21,4 @@ Ecology.propTypes = {
   overview: React.PropTypes.string,
   source: React.PropTypes.object,
   scope: React.PropTypes.object
-}
+};

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -6,9 +6,9 @@ import Overview from "./overview";
 export default class Ecology extends React.Component {
   render() {
     return (
-      <div className="ecology-wrapper">
-        <Overview markdown={this.props.overview} scope={this.props.scope}/>
-        <API source={this.props.source}/>
+      <div className="Ecology">
+        <div className="Overview"><Overview markdown={this.props.overview} scope={this.props.scope}/></div>
+        <div className="Documentation"><API source={this.props.source}/></div>
       </div>
     );
   }

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -12,7 +12,7 @@ class Overview extends React.Component {
       if (playgrounds.hasOwnProperty(p)) {
         let source = playgrounds[p].innerText;
         React.render(
-          <Playground codeText={source} scope={this.props.scope} noRender={true}/>,
+          <div className="Interactive"><Playground codeText={source} scope={this.props.scope} noRender={true}/></div>,
           playgrounds[p].parentNode
         );
       }
@@ -22,7 +22,7 @@ class Overview extends React.Component {
       if (playgroundsNoRender.hasOwnProperty(p)) {
         let source = playgroundsNoRender[p].innerText;
         React.render(
-          <Playground codeText={source} scope={this.props.scope} noRender={false}/>,
+          <div className="Interactive"><Playground codeText={source} scope={this.props.scope} noRender={false}/></div>,
           playgroundsNoRender[p].parentNode
         );
       }

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM , { findDOMNode } from 'react-dom';
 import marked from "marked";
 import Playground from "component-playground";
 
@@ -7,11 +8,11 @@ class Overview extends React.Component {
     this.renderPlaygrounds();
   }
   renderPlaygrounds() {
-    const playgrounds = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground"), 0);
+    const playgrounds = Array.prototype.slice.call(ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground"), 0);
     for (const p in playgrounds) {
       if (playgrounds.hasOwnProperty(p)) {
         const source = playgrounds[p].innerText;
-        React.render(
+        ReactDOM.render(
           <div className="Interactive">
             <Playground
               codeText={source}
@@ -23,11 +24,11 @@ class Overview extends React.Component {
         );
       }
     }
-    const playgroundsNoRender = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground_norender"), 0);
+    const playgroundsNoRender = Array.prototype.slice.call(ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground_norender"), 0);
     for (const p in playgroundsNoRender) {
       if (playgroundsNoRender.hasOwnProperty(p)) {
         const source = playgroundsNoRender[p].innerText;
-        React.render(
+        ReactDOM.render(
           <div className="Interactive">
             <Playground
               codeText={source}

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -7,35 +7,43 @@ class Overview extends React.Component {
     this.renderPlaygrounds();
   }
   renderPlaygrounds() {
-    let playgrounds = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName('lang-playground'), 0);
-    for (let p in playgrounds) {
+    const playgrounds = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground"), 0);
+    for (const p in playgrounds) {
       if (playgrounds.hasOwnProperty(p)) {
-        let source = playgrounds[p].innerText;
+        const source = playgrounds[p].innerText;
         React.render(
-          <div className="Interactive"><Playground codeText={source} scope={this.props.scope} noRender={true}/></div>,
+          <div className="Interactive">
+            <Playground codeText={source} scope={this.props.scope} noRender={true}/>
+          </div>,
           playgrounds[p].parentNode
         );
       }
     }
-    let playgroundsNoRender = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName('lang-playground_norender'), 0);
-    for (let p in playgroundsNoRender) {
+    const playgroundsNoRender = Array.prototype.slice.call(React.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground_norender"), 0);
+    for (const p in playgroundsNoRender) {
       if (playgroundsNoRender.hasOwnProperty(p)) {
-        let source = playgroundsNoRender[p].innerText;
+        const source = playgroundsNoRender[p].innerText;
         React.render(
-          <div className="Interactive"><Playground codeText={source} scope={this.props.scope} noRender={false}/></div>,
+          <div className="Interactive">
+            <Playground codeText={source} scope={this.props.scope} noRender={false}/>
+          </div>,
           playgroundsNoRender[p].parentNode
         );
       }
     }
   }
   render() {
-  let markdown = marked(this.props.markdown);
+    const markdown = marked(this.props.markdown);
     return (
       <div ref="overview" dangerouslySetInnerHTML={{__html: markdown}}>
       </div>
-    )
+    );
   }
 }
 
-
 export default Overview;
+
+Overview.propTypes = {
+  markdown: React.PropTypes.string,
+  scope: React.PropTypes.object
+};

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -13,7 +13,11 @@ class Overview extends React.Component {
         const source = playgrounds[p].innerText;
         React.render(
           <div className="Interactive">
-            <Playground codeText={source} scope={this.props.scope} noRender={true}/>
+            <Playground
+              codeText={source}
+              scope={this.props.scope}
+              noRender={true}
+              theme={this.props.playgroundtheme ? this.props.playgroundtheme : "monokai"}/>
           </div>,
           playgrounds[p].parentNode
         );
@@ -25,7 +29,11 @@ class Overview extends React.Component {
         const source = playgroundsNoRender[p].innerText;
         React.render(
           <div className="Interactive">
-            <Playground codeText={source} scope={this.props.scope} noRender={false}/>
+            <Playground
+              codeText={source}
+              scope={this.props.scope}
+              noRender={false}
+              theme={this.props.playgroundtheme ? this.props.playgroundtheme : "monokai"}/>
           </div>,
           playgroundsNoRender[p].parentNode
         );
@@ -45,5 +53,6 @@ export default Overview;
 
 Overview.propTypes = {
   markdown: React.PropTypes.string,
+  playgroundtheme: React.PropTypes.string,
   scope: React.PropTypes.object
 };


### PR DESCRIPTION
I updated the class names to follow the naming conventions we use elsewhere ([sweeet SUIT](https://github.com/suitcss/suit)). I wanted to keep it consistent, but flexible. 
- Added `.Interactive` wrapper for playground
- Added `.Overview` and `.Documentation` wrappers for each component 
- Updated `.Props` table and its descendant class names
- Add `playgroundtheme` prop to change the theme of the `<Playground>` component
- Fix some lint errors 

@kenwheeler @boygirl Thoughts? 
