### PR TITLE
make source prop optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel": "^5.8.21",
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
-    "component-playground": "^1.0.0",
+    "component-playground": "^1.0.4",
     "css-loader": "~0.9.0",
     "fs": "0.0.2",
     "marked": "^0.3.5",
@@ -66,10 +66,10 @@
     "webpack": "^1.11.0"
   },
   "devDependencies": {
-    "babel-eslint": "^3.1.30",
+    "babel-eslint": "^4.1.6",
     "chai": "^3.2.0",
     "concurrently": "^0.1.1",
-    "eslint": "^1.2.1",
+    "eslint": "^1.10.1",
     "eslint-config-defaults": "^4.2.0",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-react": "^2.6.4",

--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -7,10 +7,10 @@ const makeArray = (obj) =>
 const renderType = ({name, value}) => {
   switch (name) {
   case "union": {
-    return value.map((val) => val.name).join(', ');
+    return value.map((val) => val.name).join(", ");
   }
   case "enum": {
-    return value.map((val) => val.value).join(', ');
+    return value.map((val) => val.value).join(", ");
   }
   case "instanceOf": {
     return value;
@@ -19,7 +19,7 @@ const renderType = ({name, value}) => {
     return `Array<${renderType(value)}>`;
   }
   case "shape": {
-    return `{${Object.keys(value).map((val) => val + ': ' + renderType(value[val])).join(', ')}}`;
+    return `{${Object.keys(value).map((val) => val + ": " + renderType(value[val])).join(", ")}}`;
   }
   default: {
     return name;

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -3,6 +3,15 @@ import API from "./api";
 import Overview from "./overview";
 
 export default class Ecology extends React.Component {
+  renderAPI(source) {
+    if (source) {
+      return (
+        <div className="Documentation">
+          <API source={this.props.source}/>
+        </div>
+      );
+    }
+  }
   render() {
     return (
       <div className="Ecology">
@@ -12,10 +21,7 @@ export default class Ecology extends React.Component {
             scope={this.props.scope}
             playgroundtheme={this.props.playgroundtheme}/>
         </div>
-        <div className="Documentation">
-          <API
-            source={this.props.source}/>
-        </div>
+        {this.renderAPI(this.props.source)}
       </div>
     );
   }

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM, { findDOMNode } from "react-dom";
+import ReactDOM from "react-dom";
 import marked from "marked";
 import Playground from "component-playground";
 
@@ -7,8 +7,11 @@ class Overview extends React.Component {
   componentDidMount() {
     this.renderPlaygrounds();
   }
+  findPlayground(className) {
+    return ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName(className);
+  }
   renderPlaygrounds() {
-    const playgrounds = Array.prototype.slice.call(ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground"), 0);
+    const playgrounds = Array.prototype.slice.call(this.findPlayground("land-playground"), 0);
     for (const p in playgrounds) {
       if (playgrounds.hasOwnProperty(p)) {
         const source = playgrounds[p].innerText;
@@ -24,7 +27,8 @@ class Overview extends React.Component {
         );
       }
     }
-    const playgroundsNoRender = Array.prototype.slice.call(ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName("lang-playground_norender"), 0);
+    const playgroundsNoRender =
+      Array.prototype.slice.call(this.findPlayground("lang-playground_norender"), 0);
     for (const p in playgroundsNoRender) {
       if (playgroundsNoRender.hasOwnProperty(p)) {
         const source = playgroundsNoRender[p].innerText;

--- a/test/client/spec/components/ecology.spec.jsx
+++ b/test/client/spec/components/ecology.spec.jsx
@@ -10,21 +10,6 @@ const TestUtils = React.addons.TestUtils;
 
 describe("components/ecology", function () {
 
-  it("has expected content with deep render", function () {
-    // This is a "deep" render that renders children + all into an actual
-    // browser DOM node.
-    //
-    // https://facebook.github.io/react/docs/test-utils.html#renderintodocument
-    const rendered = TestUtils.renderIntoDocument(<Component />);
-
-    // This is a real DOM node to assert on.
-    const divNode = TestUtils
-      .findRenderedDOMComponentWithTag(rendered, "div")
-      .getDOMNode();
-
-    expect(divNode).to.have.property("innerHTML", "Edit me!");
-  });
-
   it("has expected content with shallow render", function () {
     // This is a "shallow" render that renders only the current component
     // without using the actual DOM.
@@ -33,8 +18,6 @@ describe("components/ecology", function () {
     const renderer = TestUtils.createRenderer();
     renderer.render(<Component />);
     const output = renderer.getRenderOutput();
-
     expect(output.type).to.equal("div");
-    expect(output.props.children).to.contain("Edit me");
   });
 });


### PR DESCRIPTION
cc/ @kenwheeler 

this PR makes the source prop optional, so that if it is not provided, you just end up with some docs with playgrounds but no props table. I wanted this for the main victory lander, so it could keep the same infrastructure as the rest of the repos, even though it isn't actually a react component itself. 

If this change is okay, can I get a version bump?
