### PR TITLE
Ignore IntelliJ project .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### SublimeText ###
 *.sublime-workspace
 
+### IntelliJ ###
+.idea
+
 ### OSX ###
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
ignore the .idea directory that is created when opening up an IntelliJ/Webstorm project.
