### PR TITLE
Ignore source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ $RECYCLE.BIN/
 .tmp
 bower_components
 coverage
+dist/*.map
 lib
 node_modules
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 *.sublime-workspace
 
 ### OSX ###
-.DS_Store
 .AppleDouble
+.DS_Store
 .LSOverride
 Icon
 
@@ -16,8 +16,8 @@ Icon
 
 ### Windows ###
 # Windows image file caches
-Thumbs.db
 ehthumbs.db
+Thumbs.db
 
 # Folder config file
 Desktop.ini
@@ -26,10 +26,9 @@ Desktop.ini
 $RECYCLE.BIN/
 
 # App specific
-
-coverage
-node_modules
-bower_components
 .tmp
+bower_components
+coverage
 lib
+node_modules
 npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,27 +1,27 @@
 # Cruft
-*.sublime-workspace
-.DS_Store
-.AppleDouble
-.LSOverride
-Icon
 ._*
+.AppleDouble
+.DS_Store
+.LSOverride
 .Spotlight-V100
-.Trashes
-Thumbs.db
-ehthumbs.db
-Desktop.ini
-$RECYCLE.BIN/
 .tmp
+.Trashes
+*.sublime-workspace
+$RECYCLE.BIN/
+Desktop.ini
+ehthumbs.db
+Icon
 npm-debug.log
+Thumbs.db
 
 # Code / build
-coverage
-node_modules
-bower_components
-demo
-test
-karma*
-webpack*
-.eslint*
 .editor*
+.eslint*
 .travis*
+bower_components
+coverage
+demo
+karma*
+node_modules
+test
+webpack*

--- a/.npmignore
+++ b/.npmignore
@@ -21,6 +21,7 @@ Thumbs.db
 bower_components
 coverage
 demo
+dist/*.map
 karma*
 node_modules
 test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Ecology Changelog
+
+## 1.1.0 (2016-01-29)
+
+  * Added usage documentation
+  * Fixed exception when component didn't specify `propTypes`
+  * Cleaned up dependencies
+
+## 1.0.4 (2015-11-27)
+
+  * Fixed firefox bug
+
+## 1.0.3 (2015-11-25)
+
+  * Fixed breaking typo
+
+## 1.0.2 (2015-11-25)
+
+  * Made props table optional
+
+## 1.0.0 (2015-10-19)
+
+  * Initial release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,7 +147,7 @@ sure that you have a very modern `npm` binary:
 $ npm install -g npm
 ```
 
-Built files in `dist/` should **not** be committeed during development or PRs.
+Built files in `dist/` should **not** be committed during development or PRs.
 Instead we _only_ build and commit them for published, tagged releases. So
 the basic workflow is:
 
@@ -156,19 +156,21 @@ the basic workflow is:
 $ git pull
 $ git status # (should be no changes)
 
+# Add version notes
+$ vim CHANGELOG.md
+$ git commit -a -m "Update CHANGELOG"
+
 # Choose a semantic update for the new version.
 # If you're unsure, read about semantic versioning at http://semver.org/
-$ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
+$ npm version major|minor|patch -m "Version %s - List of features"
 
 # ... the `dist/` and `lib/` directories are now built, `package.json` is
 # updated, and the appropriate files are committed to git (but unpushed).
 #
 # *Note*: `lib/` is uncommitted, but built and must be present to push to npm.
 
-# Check that everything looks good in last commit and push.
-$ git diff HEAD^ HEAD
-$ git push && git push --tags
-# ... the project is now pushed to GitHub and available to `bower`.
+# Push the commit and tag
+$ git push --follow-tags
 
 # And finally publish to `npm`!
 $ npm publish

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis Status][trav_img]][trav_site]
+![](https://badge-size.herokuapp.com/FormidableLabs/ecology/master/dist/ecology.min.js?compression=gzip)
 
 Ecology
 ===========================
@@ -22,7 +23,7 @@ $ npm run dev && npm run open-demo
 2. Your component should define `propTypes` [in the `createClass` object literal](https://github.com/reactjs/react-docgen#example) or as a static property of the class.
 3. Your component may define default props as `getDefaultProps` method (`React.createClass()` syntax), or as a `defaultProps` static property of the class.
 4. You should add a JSDoc-style comment block for each prop, with a description and optional `@examples`.
-        
+
   ```jsx
   // createClass() example
   const MyComponent = React.createClass({
@@ -33,12 +34,12 @@ $ npm run dev && npm run open-demo
        */
       testProp: React.PropTypes.string
     },
-  
+
     render() {
       return <div>Sample</div>;
     }
   });
-  
+
   // class declaration example
   // NOTE: Requires `babel-preset-stage-1`
   class MyComponent extends React.Component {
@@ -49,7 +50,7 @@ $ npm run dev && npm run open-demo
        */
       testProp: React.PropTypes.string
     };
-  
+
     render() {
       return <div>Sample</div>;
     }


### PR DESCRIPTION
Source maps are huge, and are a big reason victory `node_modules` is so large.
- Add `dist/*.map` to `.npmignore`
- Add `dist/*.map` to `.gitignore` **<-- do we want to do this?**
- Add CHANGELOG
- Update DEVELOPMENT guide
