### PR TITLE
Render Playground on ComponentDidUpdate

### DIFF
--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -7,6 +7,9 @@ class Overview extends React.Component {
   componentDidMount() {
     this.renderPlaygrounds();
   }
+  componentDidUpdate() {
+    this.renderPlaygrounds();
+  }
   findPlayground(className) {
     return ReactDOM.findDOMNode(this.refs.overview).getElementsByClassName(className);
   }


### PR DESCRIPTION
Component playground only renders on initial render. In some situations, if Ecology is updated with props, it would not update the playground, because it was already instantiated. Adding render in componentDidUpdate fixes this.

Could also possibly explore non-ref solutions.
