### PR TITLE
Upgrade lodash and stylus-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "css-loader": "~0.9.0",
     "fs": "0.0.2",
     "json-loader": "^0.5.4",
+    "lodash": "^4.13.1",
     "marked": "^0.3.5",
     "radium": "^0.17.1",
     "raw-loader": "^0.5.1",
@@ -93,7 +94,6 @@
     "karma-sauce-launcher": "^0.2.14",
     "karma-spec-reporter": "0.0.20",
     "karma-webpack": "^1.7.0",
-    "lodash": "^3.10.1",
     "mocha": "^2.2.5",
     "opener": "^1.4.1",
     "phantomjs": "^1.9.18",
@@ -102,7 +102,7 @@
     "sinon": "^1.16.1",
     "sinon-chai": "^2.8.0",
     "style-loader": "~0.8.0",
-    "stylus-loader": "^1.4.2",
+    "stylus-loader": "^2.1.1",
     "url-loader": "~0.5.5",
     "webpack-dev-server": "^1.14.0"
   }


### PR DESCRIPTION
Fixes #35

From what we could tell, the `babel-template` dependency relied on a newer version of `lodash` than we were including in our project. NPM dependency flattening may have been the root of the issue.

cc @coopy
