### PR TITLE
Add support for marked renderer overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Create these files according to the below examples:
 - __Source__ - React class source file in parsed [`react-docgen`](https://github.com/reactjs/react-docgen) format
 - __Scope__ - Scope for `component-playground` components. Used by Component Playground to render live code snippets. It needs React, ReactDOM, and your component.
 
+### Optional Props
+
+- __rendererOverrides__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer overrides. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764).
+
 ## Deploying Your Docs
 
 Help us write this documentation!

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Create these files according to the below examples:
 
 ### Optional Props
 
-- __customRenderers__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer methods. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764). *Note:* Method must return a string.
+- __customRenderers__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer methods. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked#renderer). *Note:* Method must return a string.
 
 ## Deploying Your Docs
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Create these files according to the below examples:
 
 ### Optional Props
 
-- __rendererOverrides__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer overrides. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764).
+- __rendererOverrides__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer overrides. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764). *Note:* Must return a string.
 
 ## Deploying Your Docs
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Create these files according to the below examples:
 
 ### Optional Props
 
-- __rendererOverrides__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer overrides. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764). *Note:* Must return a string.
+- __customRenderers__ - Pass an object with custom [marked](https://github.com/chjj/marked) renderer methods. ex `link: function(href, title, text) {return href}`. A list of available elements is [available here](https://github.com/chjj/marked/blob/88ce4df47c4d994dc1b1df1477a21fb893e11ddc/lib/marked.js#L764). *Note:* Method must return a string.
 
 ## Deploying Your Docs
 

--- a/demo/docs.jsx
+++ b/demo/docs.jsx
@@ -15,7 +15,8 @@ class Docs extends React.Component {
           overview={require("!!raw!./ecology.md")}
           source={docgen.parse(require("!!raw!./sample"))}
           scope={{React, ReactDOM, SampleClass}}
-          playgroundtheme="blackboard"/>
+          playgroundtheme="blackboard"
+        />
       </div>
     );
   }

--- a/demo/docs.jsx
+++ b/demo/docs.jsx
@@ -16,7 +16,7 @@ class Docs extends React.Component {
           source={docgen.parse(require("!!raw!./sample"))}
           scope={{React, ReactDOM, SampleClass}}
           playgroundtheme="blackboard"
-          rendererOverrides={{
+          customRenderers={{
             link: function(href, title, text) {
               return `<a href=${href} target="_blank">${text}</a>`;
             }

--- a/demo/docs.jsx
+++ b/demo/docs.jsx
@@ -16,6 +16,11 @@ class Docs extends React.Component {
           source={docgen.parse(require("!!raw!./sample"))}
           scope={{React, ReactDOM, SampleClass}}
           playgroundtheme="blackboard"
+          rendererOverrides={{
+            link: function(href, title, text) {
+              return `<a href=${href} target="_blank">${text}</a>`;
+            }
+          }}
         />
       </div>
     );

--- a/demo/docs.jsx
+++ b/demo/docs.jsx
@@ -17,9 +17,7 @@ class Docs extends React.Component {
           scope={{React, ReactDOM, SampleClass}}
           playgroundtheme="blackboard"
           customRenderers={{
-            link: function(href, title, text) {
-              return `<a href=${href} target="_blank">${text}</a>`;
-            }
+            link: (href, title, text) => `<a href=${href} target="_blank">${text}</a>`
           }}
         />
       </div>

--- a/demo/ecology.md
+++ b/demo/ecology.md
@@ -14,4 +14,4 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ## Automatic Prop Table
-The Prop Table below is automatically generated from comments in the component, see `sample.jsx`. [Link](http://google.com)
+The Prop Table below is automatically generated from comments in the component, see `sample.jsx`.

--- a/demo/ecology.md
+++ b/demo/ecology.md
@@ -14,4 +14,4 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ## Automatic Prop Table
-The Prop Table below is automatically generated from comments in the component, see `sample.jsx`.
+The Prop Table below is automatically generated from comments in the component, see `sample.jsx`. [Link](http://google.com)

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -19,6 +19,7 @@ export default class Ecology extends React.Component {
           <Overview
             markdown={this.props.overview}
             scope={this.props.scope}
+            rendererOverrides={this.props.rendererOverrides}
             playgroundtheme={this.props.playgroundtheme}/>
         </div>
         {this.renderAPI(this.props.source)}
@@ -30,6 +31,7 @@ export default class Ecology extends React.Component {
 Ecology.propTypes = {
   overview: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
+  rendererOverrides: React.PropTypes.array,
   source: React.PropTypes.object,
   scope: React.PropTypes.object
 };

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -31,7 +31,7 @@ export default class Ecology extends React.Component {
 Ecology.propTypes = {
   overview: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
-  rendererOverrides: React.PropTypes.array,
+  rendererOverrides: React.PropTypes.object,
   source: React.PropTypes.object,
   scope: React.PropTypes.object
 };

--- a/src/components/ecology.jsx
+++ b/src/components/ecology.jsx
@@ -19,7 +19,7 @@ export default class Ecology extends React.Component {
           <Overview
             markdown={this.props.overview}
             scope={this.props.scope}
-            rendererOverrides={this.props.rendererOverrides}
+            customRenderers={this.props.customRenderers}
             playgroundtheme={this.props.playgroundtheme}/>
         </div>
         {this.renderAPI(this.props.source)}
@@ -31,7 +31,7 @@ export default class Ecology extends React.Component {
 Ecology.propTypes = {
   overview: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
-  rendererOverrides: React.PropTypes.object,
+  customRenderers: React.PropTypes.object,
   source: React.PropTypes.object,
   scope: React.PropTypes.object
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -46,12 +46,12 @@ class Overview extends React.Component {
     }
   }
   renderMarkdown() {
-    const { rendererOverrides, markdown } = this.props;
+    const { customRenderers, markdown } = this.props;
     let renderedMarkdown = marked(markdown);
 
-    if (rendererOverrides) {
+    if (customRenderers) {
       const renderer = new marked.Renderer();
-      Object.keys(rendererOverrides).forEach((key) => renderer[key] = rendererOverrides[key]);
+      Object.keys(customRenderers).forEach((key) => renderer[key] = customRenderers[key]);
       renderedMarkdown = marked(markdown, { renderer });
     }
 
@@ -68,12 +68,12 @@ class Overview extends React.Component {
 export default Overview;
 
 Overview.defaultProps = {
-  rendererOverrides: null
+  customRenderers: null
 };
 
 Overview.propTypes = {
   markdown: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
-  rendererOverrides: React.PropTypes.object,
+  customRenderers: React.PropTypes.object,
   scope: React.PropTypes.object
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -50,10 +50,12 @@ class Overview extends React.Component {
     let renderedMarkdown = marked(markdown);
 
     if(rendererOverrides) {
-      for(const r in rendererOverrides) {
-        const renderer = new marked.Renderer();
-        console.log(marked(markdown, { renderer: r }));
-      }
+      const renderer = new marked.Renderer();
+
+      Object.keys(rendererOverrides).forEach((key) => {
+       renderer[key] = rendererOverrides[key];
+       console.log(marked(markdown, { renderer: renderer }));
+     });
     }
 
     return renderedMarkdown;
@@ -70,18 +72,18 @@ class Overview extends React.Component {
 export default Overview;
 
 Overview.defaultProps = {
-  rendererOverrides: [{
-    link: function(text, level, something) {
-      console.log(text, level, something)
+  rendererOverrides: {
+    link: function(href, title, text) {
+      console.log(href, title, text)
 
       return text;
     }
-  }],
+  },
 };
 
 Overview.propTypes = {
   markdown: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
-  rendererOverrides: React.PropTypes.array,
+  rendererOverrides: React.PropTypes.object,
   scope: React.PropTypes.object,
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -49,14 +49,10 @@ class Overview extends React.Component {
     const { rendererOverrides, markdown } = this.props;
     let renderedMarkdown = marked(markdown);
 
-    if(rendererOverrides) {
+    if (rendererOverrides) {
       const renderer = new marked.Renderer();
-
-      Object.keys(rendererOverrides).forEach((key) => {
-        return renderer[key] = rendererOverrides[key];
-      });
-
-     renderedMarkdown = marked(markdown, { renderer: renderer });
+      Object.keys(rendererOverrides).forEach((key) => renderer[key] = rendererOverrides[key]);
+      renderedMarkdown = marked(markdown, { renderer });
     }
 
     return renderedMarkdown;
@@ -72,12 +68,12 @@ class Overview extends React.Component {
 export default Overview;
 
 Overview.defaultProps = {
-  rendererOverrides: null,
+  rendererOverrides: null
 };
 
 Overview.propTypes = {
   markdown: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
   rendererOverrides: React.PropTypes.object,
-  scope: React.PropTypes.object,
+  scope: React.PropTypes.object
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -45,10 +45,23 @@ class Overview extends React.Component {
       }
     }
   }
+  renderMarkdown() {
+    const { rendererOverrides, markdown } = this.props;
+    let renderedMarkdown = marked(markdown);
+
+    if(rendererOverrides) {
+      for(const r in rendererOverrides) {
+        const renderer = new marked.Renderer();
+        console.log(marked(markdown, { renderer: r }));
+      }
+    }
+
+    return renderedMarkdown;
+  }
   render() {
-    const markdown = marked(this.props.markdown);
+
     return (
-      <div ref="overview" dangerouslySetInnerHTML={{__html: markdown}}>
+      <div ref="overview" dangerouslySetInnerHTML={{__html: this.renderMarkdown()}}>
       </div>
     );
   }
@@ -56,8 +69,19 @@ class Overview extends React.Component {
 
 export default Overview;
 
+Overview.defaultProps = {
+  rendererOverrides: [{
+    link: function(text, level, something) {
+      console.log(text, level, something)
+
+      return text;
+    }
+  }],
+};
+
 Overview.propTypes = {
   markdown: React.PropTypes.string,
   playgroundtheme: React.PropTypes.string,
-  scope: React.PropTypes.object
+  rendererOverrides: React.PropTypes.array,
+  scope: React.PropTypes.object,
 };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -53,9 +53,10 @@ class Overview extends React.Component {
       const renderer = new marked.Renderer();
 
       Object.keys(rendererOverrides).forEach((key) => {
-       renderer[key] = rendererOverrides[key];
-       console.log(marked(markdown, { renderer: renderer }));
-     });
+        return renderer[key] = rendererOverrides[key];
+      });
+
+     renderedMarkdown = marked(markdown, { renderer: renderer });
     }
 
     return renderedMarkdown;
@@ -63,8 +64,7 @@ class Overview extends React.Component {
   render() {
 
     return (
-      <div ref="overview" dangerouslySetInnerHTML={{__html: this.renderMarkdown()}}>
-      </div>
+      <div ref="overview" dangerouslySetInnerHTML={{__html: this.renderMarkdown()}} />
     );
   }
 }
@@ -72,13 +72,7 @@ class Overview extends React.Component {
 export default Overview;
 
 Overview.defaultProps = {
-  rendererOverrides: {
-    link: function(href, title, text) {
-      console.log(href, title, text)
-
-      return text;
-    }
-  },
+  rendererOverrides: null,
 };
 
 Overview.propTypes = {

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -47,18 +47,14 @@ class Overview extends React.Component {
   }
   renderMarkdown() {
     const { customRenderers, markdown } = this.props;
-    let renderedMarkdown = marked(markdown);
-
     if (customRenderers) {
       const renderer = new marked.Renderer();
-      Object.keys(customRenderers).forEach((key) => renderer[key] = customRenderers[key]);
-      renderedMarkdown = marked(markdown, { renderer });
+      Object.assign(renderer, customRenderers);
+      return marked(markdown, { renderer });
     }
-
-    return renderedMarkdown;
+    return marked(markdown);
   }
   render() {
-
     return (
       <div ref="overview" dangerouslySetInnerHTML={{__html: this.renderMarkdown()}} />
     );


### PR DESCRIPTION
The [marked](https://github.com/chjj/marked) used for markdown rendering supports the ability to override renderer defaults. This feature adds the ability for developers to pass an object with renderer methods to Ecology via the `rendererOverrides` props.

This is non-breaking.

cc @coopy @paulathevalley
