### PR TITLE
update babel core to 6.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "babel-cli": "^6.5.1",
-    "babel-core": "^6.5.2",
+    "babel-core": "^6.10.4",
     "babel-loader": "^6.2.3",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
This updates Babel-Core to eliminate a deprecated minimatch warning that users were getting when installing Victory. https://github.com/FormidableLabs/victory/issues/286

@boygirl 
