### PR TITLE
Custom markdown formatting of code element

### DIFF
--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -59,27 +59,27 @@ class Overview extends React.Component {
             .replace(/'/g, "&#39;");
         };
 
-          if (!lang) {
-            return (
-              `<pre><code>${escape(code)}</code></pre>`
-            );
-          }
+        if (!lang) {
+          return (
+            `<pre><code>${escape(code)}</code></pre>`
+          );
+        }
 
-          if (lang === "playground" || lang === "playground_norender") {
-            return (
-              `<pre>
-                <code class="lang-${escape(lang)}">
-                  <span class="ecologyCode">${escape(code)}</span>
-                </code>
-              </pre>`
-            );
-          }
-
+        if (lang === "playground" || lang === "playground_norender") {
           return (
             `<pre>
-              <code class="lang-${escape(lang)}">${escape(code)}</code>
+              <code class="lang-${escape(lang)}">
+                <span class="ecologyCode">${escape(code)}</span>
+              </code>
             </pre>`
           );
+        }
+
+        return (
+          `<pre>
+            <code class="lang-${escape(lang)}">${escape(code)}</code>
+          </pre>`
+        );
       },
       ...customRenderers
     };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -14,7 +14,7 @@ class Overview extends React.Component {
     const playgrounds = Array.prototype.slice.call(this.findPlayground("lang-playground"), 0);
     for (const p in playgrounds) {
       if (playgrounds.hasOwnProperty(p)) {
-        const source = playgrounds[p].textContent;
+        const source = playgrounds[p].getElementsByClassName("ecologyCode")[0].textContent;
         ReactDOM.render(
           <div className="Interactive">
             <Playground
@@ -31,7 +31,7 @@ class Overview extends React.Component {
       Array.prototype.slice.call(this.findPlayground("lang-playground_norender"), 0);
     for (const p in playgroundsNoRender) {
       if (playgroundsNoRender.hasOwnProperty(p)) {
-        const source = playgroundsNoRender[p].textContent;
+        const source = playgroundsNoRender[p].getElementsByClassName("ecologyCode")[0].textContent;
         ReactDOM.render(
           <div className="Interactive">
             <Playground
@@ -47,12 +47,44 @@ class Overview extends React.Component {
   }
   renderMarkdown() {
     const { customRenderers, markdown } = this.props;
-    if (customRenderers) {
-      const renderer = new marked.Renderer();
-      Object.assign(renderer, customRenderers);
-      return marked(markdown, { renderer });
+    const renderer = new marked.Renderer();
+    const renderers = {
+        code: (code, lang) => {
+            escape(html) => {
+              return html
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+            }
+
+            if (!lang) {
+              return (
+                `<pre><code>${escape(code)}</code></pre>`
+              );
+            }
+
+            if (lang === "playground" || lang === "playground_norender") {
+              return (
+                `<pre>
+                  <code class="lang-${escape(lang)}">
+                    <span class="ecologyCode">${escape(code)}</span>
+                  </code>
+                </pre>`
+              );
+            }
+
+            return (
+              `<pre>
+                <code class="lang-${escape(lang)}">${escape(code)}</code>
+              </pre>`
+            );
+        },
+        ...customRenderers
     }
-    return marked(markdown);
+    Object.assign(renderer, renderers);
+    return marked(markdown, { renderer });
   }
   render() {
     return (

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -50,14 +50,14 @@ class Overview extends React.Component {
     const renderer = new marked.Renderer();
     const renderers = {
         code: (code, lang) => {
-            function escape(html) {
-              return html
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&#39;');
-            }
+          const escape = (html) => {
+            return html
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;")
+              .replace(/'/g, "&#39;");
+          };
 
             if (!lang) {
               return (

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -49,40 +49,40 @@ class Overview extends React.Component {
     const { customRenderers, markdown } = this.props;
     const renderer = new marked.Renderer();
     const renderers = {
-        code: (code, lang) => {
-          const escape = (html) => {
-            return html
-              .replace(/&/g, "&amp;")
-              .replace(/</g, "&lt;")
-              .replace(/>/g, "&gt;")
-              .replace(/"/g, "&quot;")
-              .replace(/'/g, "&#39;");
-          };
+      code: (code, lang) => {
+        const escape = (html) => {
+          return html
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+        };
 
-            if (!lang) {
-              return (
-                `<pre><code>${escape(code)}</code></pre>`
-              );
-            }
+          if (!lang) {
+            return (
+              `<pre><code>${escape(code)}</code></pre>`
+            );
+          }
 
-            if (lang === "playground" || lang === "playground_norender") {
-              return (
-                `<pre>
-                  <code class="lang-${escape(lang)}">
-                    <span class="ecologyCode">${escape(code)}</span>
-                  </code>
-                </pre>`
-              );
-            }
-
+          if (lang === "playground" || lang === "playground_norender") {
             return (
               `<pre>
-                <code class="lang-${escape(lang)}">${escape(code)}</code>
+                <code class="lang-${escape(lang)}">
+                  <span class="ecologyCode">${escape(code)}</span>
+                </code>
               </pre>`
             );
-        },
-        ...customRenderers
-    }
+          }
+
+          return (
+            `<pre>
+              <code class="lang-${escape(lang)}">${escape(code)}</code>
+            </pre>`
+          );
+      },
+      ...customRenderers
+    };
     Object.assign(renderer, renderers);
     return marked(markdown, { renderer });
   }

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -50,7 +50,7 @@ class Overview extends React.Component {
     const renderer = new marked.Renderer();
     const renderers = {
         code: (code, lang) => {
-            escape(html) => {
+            function escape(html) {
               return html
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')


### PR DESCRIPTION
Basically creating custom markup based on the language provided. If it's a playground, we will nest the code inside a named `<span>`. This will allow developers to define custom `code` renderers that ecology can still interpret.

Here is an example for a loading state I intend to use inside the victory-docs:

```
if (lang === "playground" || lang === "playground_norender") {
      return (
        `<pre style="line-height: 0">
            <div class="lang-${escape(lang)}">
                <span class="ecologyCode" style="display:none;">${escape(code)}</span>
                <div class="Interactive">
                    <div style="display: flex;flex-direction: row;flex-wrap: nowrap;align-items: stretch;justify-content: space-between;margin-left: -20px;padding: 0;">
                        <div style="min-height:300px;display: flex;flex: 1 2 45%;margin: 0;">
                        </div>
                        <div style="min-height:300px;display: flex;flex: 3 2 55%;margin: 0;padding: 0;">
                            <div class="ReactCodeMirror playgroundStage"></div>
                        </div>
                    </div>
                </div>
            </div>
        </pre>`
      );
    }
```

Open to suggestions on how this might be improved. I'm a little shaky on using `.getElementsByClassName("ecologyCode")[0]` to get the DOM node with the code in it, but it seems like one solution.

cc @paulathevalley 
