### PR TITLE
use regular strings instead of templates

### DIFF
--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -59,27 +59,16 @@ class Overview extends React.Component {
             .replace(/'/g, "&#39;");
         };
 
+        // Use regular strings, es6 templates cause spaces to be inserted
         if (!lang) {
-          return (
-            `<pre><code>${escape(code)}</code></pre>`
-          );
+          return ('<pre><code>' + escape(code) + '</code></pre>');
         }
 
         if (lang === "playground" || lang === "playground_norender") {
-          return (
-            `<pre>
-              <code class="lang-${escape(lang)}">
-                <span class="ecologyCode">${escape(code)}</span>
-              </code>
-            </pre>`
-          );
+          return ('<pre><code class="lang-' + escape(lang) + '"><span class="ecologyCode">' + escape(code) + '</span></code></pre>');
         }
 
-        return (
-          `<pre>
-            <code class="lang-${escape(lang)}">${escape(code)}</code>
-          </pre>`
-        );
+        return ('<pre><code class="lang-' + escape(lang) + '">' + escape(code) + '</code></pre>');
       },
       ...customRenderers
     };

--- a/src/components/overview.jsx
+++ b/src/components/overview.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from "react";
 import ReactDOM from "react-dom";
 import marked from "marked";
@@ -58,17 +59,16 @@ class Overview extends React.Component {
             .replace(/"/g, "&quot;")
             .replace(/'/g, "&#39;");
         };
-
         // Use regular strings, es6 templates cause spaces to be inserted
         if (!lang) {
-          return ('<pre><code>' + escape(code) + '</code></pre>');
+          return ("<pre><code>" + escape(code) + "</code></pre>");
         }
 
         if (lang === "playground" || lang === "playground_norender") {
-          return ('<pre><code class="lang-' + escape(lang) + '"><span class="ecologyCode">' + escape(code) + '</span></code></pre>');
+          return ("<pre><code class='lang-" + escape(lang) + "'><span class='ecologyCode'>" + escape(code) + "</span></code></pre>");
         }
 
-        return ('<pre><code class="lang-' + escape(lang) + '">' + escape(code) + '</code></pre>');
+        return ("<pre><code class='lang-" + escape(lang) + "'>" + escape(code) + "</code></pre>");
       },
       ...customRenderers
     };


### PR DESCRIPTION
Though this is tough to look at, template strings & tag-alignment introduced spaces into the rendered code. This fixes the added spaces issue.

cc @paulathevalley 
