### PR TITLE
prevent crash due to enum/union props that don't resolve to array literals

### DIFF
--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -7,10 +7,16 @@ const makeArray = (obj) =>
 const renderType = ({name, value}) => {
   switch (name) {
   case "union": {
-    return value.map((val) => val.name).join(", ");
+    if (Array.isArray(value)) {
+      return value.map((val) => val.name).join(", ");
+    }
+    return value;
   }
   case "enum": {
-    return value.map((val) => val.value).join(", ");
+    if (Array.isArray(value)) {
+      return value.map((val) => val.value).join(", ");
+    }
+    return value;
   }
   case "instanceOf": {
     return value;


### PR DESCRIPTION
React Docgen sometimes returns a variable name (a string) instead of an array for component properties that are enums or unions, causing a "function undefined" error when value.map() is called.
