### PR TITLE
[API Doc] Adds support for flow props types

### DIFF
--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -27,6 +27,21 @@ const renderType = ({name, value}) => {
   }
 };
 
+const renderFlowType = ({name, raw, type}) => {
+  // Signature type (object or function)
+  // See https://github.com/reactjs/react-docgen/blob/
+  //        dca8ec9d57b4833f7ddb3164bedf4d74578eee1e/src/utils/getFlowType.js
+  if (name === "signature") {
+    return `${type} : ${raw}`;
+  }
+  // Composite type :
+  if (raw) {
+    return raw;
+  }
+  // Primitive type :
+  return name;
+};
+
 export default class API extends React.Component {
   render() {
     const docObj = this.props.source;
@@ -51,7 +66,11 @@ export default class API extends React.Component {
                     {prop.name}
                   </span>
                   <span className="Prop-type">
-                    {renderType({...prop.type})}
+                    {
+                      prop.flowType
+                        ? renderFlowType({...prop.flowType})
+                        : renderType({...prop.type})
+                    }
                   </span>
                   {prop.required && <span className="Prop-required">required</span>}
                 </td>


### PR DESCRIPTION
react-docgen parses correctly propTypes annotated with FlowType, but Ecology does not use the resulting keys in the object passed as its `source` prop. Currently, the props of a component using only React.PropTypes without Flow types are displayed correctly for the JSDoc description and the required status, but no type is displayed.

This pull request aims to provide support for FlowType-annotated props, by checking if there is a `flowType` key for the prop description it is rendering. It chooses to privilege flow proptypes over static `propTypes` attribute, because Flow is more precise.

There are three possible cases : 
### \- `signature` type name (object shape or function) :

We render the type's name + its raw annotation, for example : 
`object : {[id: string]: number}` or `function : (value: string) => number`
### \- `raw` type without signature (enum, array, union ...)

We render the raw type annotation, for example : 
`Array<string>`
### \- primitive types :

We render the type's name.

Related source code : getFlowType.js from react-docgen :
https://github.com/reactjs/react-docgen/blob/dca8ec9d57b4833f7ddb3164bedf4d74578eee1e/src/utils/getFlowType.js
